### PR TITLE
Add OneDrive as possible url source

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -144,7 +144,7 @@ var (
 		regexp.MustCompile(`ダウンロード(?:<\/span>)?<\/a><\/p><p>[\w-]+<\/p>`),
 		regexp.MustCompile(`ダウンロード\n([\w-]+)\n`),
 	}
-	EXTERNAL_DOWNLOAD_PLATFORMS = [...]string{"mega", "gigafile", "dropbox", "mediafire"}
+	EXTERNAL_DOWNLOAD_PLATFORMS = [...]string{"mega", "gigafile", "dropbox", "mediafire", "1drv.ms"}
 
 	// For GDrive
 	GDRIVE_URL_REGEX = regexp.MustCompile(


### PR DESCRIPTION
# Addition to code

## Type of additions (Tick those that apply):

<!-- Use ✗/✓ for the following type of additions -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Package Version

Version: <!-- 1.0.0 or based on my latest commit [aeb698a](https://github.com/KJHJason/Cultured-Downloader-Logic/commit/aeb698a058f9b605c8c02bd6c1284690dc1ab5d8) -->

## Summary of changes:

Just add OneDrive as an allowed hoster. This causes 1drv.ms links to generate a `detected_external_links.txt` with the corresponding links

## Checklist (Tick those that apply):

<!-- Use ✗/✓ for the following checklist -->

- [x] I have read the [contribution guidelines](https://github.com/KJHJason/Cultured-Downloader-Logic/blob/main/CONTRIBUTING.md) and have adhered to it
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any spelling mistakes

## Screenshots (if any):

<!-- This is used for comparing any changes via screenshots -->
| Original            | Updated            |
| ------------------- |:------------------:|
| original screenshot | updated screenshot |
